### PR TITLE
[ci skip] Remove Google cloud build config

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,0 @@
-steps:
-  - name: 'gcr.io/cloud-builders/docker'
-    args: [ "build", "-f", "Dockerfile", "--tag=gcr.io/$PROJECT_ID/musl-cross", "." ]
-    timeout: "3600s"
-timeout: "3600s"


### PR DESCRIPTION
[ci skip]

We use Travis CI now.