### PR TITLE
Be portable with `tail`

### DIFF
--- a/travis-build-scripts/build_image.sh
+++ b/travis-build-scripts/build_image.sh
@@ -14,7 +14,7 @@ touch $BUILD_OUTPUT
 
 dump_output() {
    echo Tailing the last 500 lines of output:
-   tail -500 $BUILD_OUTPUT  
+   tail -n 500 $BUILD_OUTPUT  
 }
 error_handler() {
   local loop_pid=$1


### PR DESCRIPTION
[ci skip]

I prefer to use `tail -n`.