### PR TITLE
Support Travis-CI crons: Don't publish images for crons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ script:
   
 after_success:
   # Don't publish for pull requests?
-  - if [[ -z $TRAVIS_PULL_REQUEST ]]; then ./travis-build-scripts/publish_image.sh; fi
+  - if [[ -z $TRAVIS_PULL_REQUEST && $TRAVIS_EVENT_TYPE != "cron" ]]; then ./travis-build-scripts/publish_image.sh; fi
 


### PR DESCRIPTION
There's no reason to publish an image for builds triggered by cron jobs
so don't!